### PR TITLE
added attachments to message request docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ Nerimity API Docs
 
 - [Message](/types/Message.md)
 - [User](/types/User.md)
-- [FileId](/types/FileID.md)
-
 ## Other
 
 - [RPC](/rpc.md)

--- a/README.md
+++ b/README.md
@@ -13,11 +13,15 @@ Nerimity API Docs
   - [BanMember](/endpoints/servers/BanMember.md)
   - [UnbanMember](/endpoints/servers/UnbanMember.md)
 
+
 ## Types
 
 - [Message](/types/Message.md)
 - [User](/types/User.md)
+- [FileId](/types/FileID.md)
 
 ## Other
 
 - [RPC](/rpc.md)
+- [CDN](/endpoints/cdn/)
+  - [CreateAttachment](/endpoints/cdn/CreateAttachment.md)

--- a/endpoints/cdn/CreateAttachment.md
+++ b/endpoints/cdn/CreateAttachment.md
@@ -12,7 +12,12 @@ POST https://cdn.nerimity.com/upload
 | Content-Type          | string    | Content type of the file                  |
 | File Content          | binary    | The binary content of the image file      |
 
-### Content-Disposition
+## Content-Disposition
+Construct of `name` and `filename`.
+#### Example
+```
+Content-Disposition: form-data; name="f"; filename="somename.jpg"
+```
 
 
 #### Response: [FileId](/types/FileId.md)

--- a/endpoints/cdn/CreateAttachment.md
+++ b/endpoints/cdn/CreateAttachment.md
@@ -5,19 +5,9 @@ Upload attachments to Nerimity's CDN
 POST https://cdn.nerimity.com/upload
 ```
 
-
 | Body (FormData)       | Type      | Description                               |
 | --------------------- | --------- | ----------------------------------------- |
-| Content-Disposition   | string    | [Idk how to describe it]                     |
-| Content-Type          | string    | Content type of the file                  |
-| File Content          | binary    | The binary content of the image file      |
-
-## Content-Disposition
-Construct of `name` and `filename`.
-#### Example
-```
-Content-Disposition: form-data; name="f"; filename="somename.jpg"
-```
+|  file                 | binary    | The binary content of the image file      |
 
 
 #### Response

--- a/endpoints/cdn/CreateAttachment.md
+++ b/endpoints/cdn/CreateAttachment.md
@@ -20,4 +20,7 @@ Content-Disposition: form-data; name="f"; filename="somename.jpg"
 ```
 
 
-#### Response: [FileId](/types/FileId.md)
+#### Response
+```json
+{"fileId": "1234.."}
+```

--- a/endpoints/cdn/CreateAttachment.md
+++ b/endpoints/cdn/CreateAttachment.md
@@ -1,0 +1,18 @@
+# Create Attachment
+Upload attachments to Nerimity's CDN
+#### Endpoint
+```
+POST https://cdn.nerimity.com/upload
+```
+
+
+| Body (FormData)       | Type      | Description                               |
+| --------------------- | --------- | ----------------------------------------- |
+| Content-Disposition   | string    | [Idk how to describe it]                     |
+| Content-Type          | string    | Content type of the file                  |
+| File Content          | binary    | The binary content of the image file      |
+
+### Content-Disposition
+
+
+#### Response: [FileId](/types/FileId.md)

--- a/endpoints/channels/CreateMessage.md
+++ b/endpoints/channels/CreateMessage.md
@@ -14,7 +14,7 @@ POST https://nerimity.com/api/channels/{CHANNEL_ID}/messages
 | ------------- | ----------------- | ----------------------------------------------------------------------- |
 | content       | String            | Your Message content                                                    |
 | socketId      | String?           | Enter your socket id to exclude the message created event for yourself. |
-| attachments   | Array?            | FileIds of Nerimity CDN to be included in the message.                  |
+| attachments   | String[]          | FileIds of Nerimity CDN to be included in the message.                  |
 
 
 

--- a/endpoints/channels/CreateMessage.md
+++ b/endpoints/channels/CreateMessage.md
@@ -10,11 +10,11 @@ POST https://nerimity.com/api/channels/{CHANNEL_ID}/messages
 | Authorization | Your User/Bot token.           |
 
 
-| Body (JSON)   | Type              | Description                                                             |
-| ------------- | ----------------- | ----------------------------------------------------------------------- |
-| content       | String            | Your Message content                                                    |
-| socketId      | String?           | Enter your socket id to exclude the message created event for yourself. |
-| attachments   | String[]          | FileIds of Nerimity CDN to be included in the message.                  |
+| Body (JSON)      | Type              | Description                                                             |
+| ---------------- | ----------------- | ----------------------------------------------------------------------- |
+| content          | String            | Your Message content                                                    |
+| socketId         | String?           | Enter your socket id to exclude the message created event for yourself. |
+| nerimityFileId   | String?            | file Id of Nerimity CDN to be included in the message.                  |
 
 
 

--- a/endpoints/channels/CreateMessage.md
+++ b/endpoints/channels/CreateMessage.md
@@ -14,5 +14,9 @@ POST https://nerimity.com/api/channels/{CHANNEL_ID}/messages
 | ------------- | ----------------- | ----------------------------------------------------------------------- |
 | content       | String            | Your Message content                                                    |
 | socketId      | String?           | Enter your socket id to exclude the message created event for yourself. |
+| attachments   | Array?            | FileIds of Nerimity CDN to be included in the message.                  |
+
+
+
 
 #### Response: [Message](/types/Message.md)

--- a/types/FileID.md
+++ b/types/FileID.md
@@ -1,5 +1,0 @@
-# FileId
-
-| key           | Type                               | Description                                   |
-| ------------- | ---------------------------------- | --------------------------------------------- |
-| fileid        | String                             | Snowflake Id of the attachment.               |

--- a/types/FileID.md
+++ b/types/FileID.md
@@ -1,0 +1,5 @@
+# FileId
+
+| key           | Type                               | Description                                   |
+| ------------- | ---------------------------------- | --------------------------------------------- |
+| fileid        | String                             | Snowflake Id of the attachment.               |


### PR DESCRIPTION
# added
- fileId type (may be unnecessary)
- `CreateAttachment` for documenting how to upload files to Nerimity CDN

# edited
- `CreateMessage`: Added attachment field